### PR TITLE
Beautifying back buttons, fixes #32

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     implementation(libs.androidx.navigation.runtime.ktx)
     implementation("com.github.PhilJay:MPAndroidChart:3.1.0")
     // Firebase BOM (Bill of Materials) - manages Firebase versions
-    implementation(platform("com.google.firebase:firebase-bom:32.7.2"))  // Update to latest
+    implementation(platform("com.google.firebase:firebase-bom:33.10.0"))  // Update to latest
     // Firebase Analytics (Required for Firebase to work) and Authentication (For login, optional but useful)
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-auth")
@@ -73,6 +73,7 @@ dependencies {
     implementation("androidx.compose.runtime:runtime:1.5.0")
     implementation("androidx.compose.ui:ui-tooling-preview:1.5.0")
     implementation(libs.androidx.media3.common.ktx)
+    implementation(libs.firebase.auth.ktx)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/habitflow/AddHabitScreen.kt
+++ b/app/src/main/java/com/example/habitflow/AddHabitScreen.kt
@@ -19,10 +19,11 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import android.content.SharedPreferences
 
 
 @Composable
-fun AddHabitScreen(navController: NavController) {
+fun AddHabitScreen(navController: NavController, sharedPreferences: SharedPreferences) {
     var habitName by remember { mutableStateOf("") }
     var habitDescription by remember { mutableStateOf("") }  // New description field
     var isGoodHabit by remember { mutableStateOf(true) }
@@ -30,6 +31,11 @@ fun AddHabitScreen(navController: NavController) {
     var showDescErrorDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
     var isBadHabit by remember { mutableStateOf(false) }
+
+    // ✅ Get the current Dark Mode value from SharedPreferences
+    var darkMode by remember {
+        mutableStateOf(sharedPreferences.getBoolean("dark_mode", false))
+    }
 
     Column(modifier = Modifier.fillMaxSize()
     ) {
@@ -44,10 +50,6 @@ fun AddHabitScreen(navController: NavController) {
                 onClick = { navController.navigate("home/") }, // Navigate to "home/"
                 modifier = Modifier
                     .size(40.dp) // Increase the size of the icon button for the bubble effect
-                    .background(
-                        color = Color(0xFFE0E0E0), // Correct Color usage
-                        shape = CircleShape // Make the background circular
-                    )
                     .padding(5.dp)
                     .align(Alignment.TopStart)
 
@@ -55,6 +57,7 @@ fun AddHabitScreen(navController: NavController) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "Back",
+                    tint = if(darkMode) Color.White else Color.Black
                 )
             }
             Text(

--- a/app/src/main/java/com/example/habitflow/MainActivity.kt
+++ b/app/src/main/java/com/example/habitflow/MainActivity.kt
@@ -59,11 +59,11 @@ class MainActivity : ComponentActivity() {
                             val isDeletingArg = backStackEntry.arguments?.getString("isDeleting") ?: "false"
                             HomeScreen(navController = navController, goodHabit = "", isDeleting = isDeletingArg)
                         }
-                        composable("addHabit") { AddHabitScreen(navController = navController) }
+                        composable("addHabit") { AddHabitScreen(navController = navController, sharedPreferences = sharedPreferences) }
                         composable("progress/{habit}/{span}") { backStackEntry ->
                             val habit = backStackEntry.arguments?.getString("habit") ?: ""
                             val span = backStackEntry.arguments?.getString("span") ?: ""
-                            ProgressScreen(navController = navController, habit = habit, span = span)
+                            ProgressScreen(navController = navController, habit = habit, span = span, sharedPreferences = sharedPreferences)
                         }
                         composable("settings") {
                             SettingsScreen(navController, isDarkMode, sharedPreferences) // ✅ Pass darkMode state and SharedPreferences

--- a/app/src/main/java/com/example/habitflow/ProgressScreen.kt
+++ b/app/src/main/java/com/example/habitflow/ProgressScreen.kt
@@ -32,10 +32,16 @@ import androidx.compose.ui.unit.sp
 ///// new import
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import android.content.SharedPreferences
 
 
 @Composable
-fun ProgressScreen(navController: NavController, habit: String, span: String) {
+fun ProgressScreen(
+    navController: NavController,
+    habit: String,
+    span: String,
+    sharedPreferences: SharedPreferences
+) {
     // Dummy data for cigarettes smoked each day (replace with actual data logic)
     val parts = habit.split(":")
     val userDataList = if (parts[2] == "good" )
@@ -53,6 +59,10 @@ fun ProgressScreen(navController: NavController, habit: String, span: String) {
         else if (span == "Monthly") { comparisonDataList[1] }
         else { comparisonDataList[2] }
 
+    // ✅ Get the current Dark Mode value from SharedPreferences
+    var darkMode by remember {
+        mutableStateOf(sharedPreferences.getBoolean("dark_mode", false))
+    }
 
     ////// Adding in variables for calculating streak, progress, and overacheiver data, and dates
 
@@ -98,10 +108,6 @@ fun ProgressScreen(navController: NavController, habit: String, span: String) {
                     onClick = { navController.navigate("home/") }, // Navigate to "home/"
                     modifier = Modifier
                         .size(40.dp) // Increase the size of the icon button for the bubble effect
-                        .background(
-                            color = Color(0xFFE0E0E0), // Correct Color usage
-                            shape = CircleShape // Make the background circular
-                        )
                         .padding(5.dp)
                         .align(Alignment.TopStart)
 
@@ -109,6 +115,7 @@ fun ProgressScreen(navController: NavController, habit: String, span: String) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "Back",
+                        tint = if(darkMode) Color.White else Color.Black
                     )
                 }
                 Text(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ composeBom = "2024.04.01"
 navigationRuntimeAndroid = "2.9.0-alpha07"
 navigationRuntimeKtx = "2.8.8"
 media3CommonKtx = "1.5.1"
+firebaseAuthKtx = "23.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -32,6 +33,7 @@ androidx-navigation-runtime-android = { group = "androidx.navigation", name = "n
 mpandroidchart = { group = "com.github.PhilJay", name = "MPAndroidChart", version = "v3.1.0" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 androidx-media3-common-ktx = { group = "androidx.media3", name = "media3-common-ktx", version.ref = "media3CommonKtx" }
+firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
 
 
 [plugins]


### PR DESCRIPTION
Changes all back arrows to follow consistent formatting for both dark and light mode, removed backdrop circles around some back buttons that were not used for others. Fixes #32 

Also has a minor update to gradle/libs.versions.toml and app/build.gradle.kts, because I was getting an issue with the firebase stuff.
