### PR TITLE
Drew stats from db

### DIFF
--- a/app/src/main/java/com/example/habitflow/AddDataScreen.kt
+++ b/app/src/main/java/com/example/habitflow/AddDataScreen.kt
@@ -100,7 +100,7 @@ fun AddDataScreen(
                             onSubmitClick = {
                                 coroutineScope.launch {
                                     when (it.trackingMethod) {
-                                        "numeric" -> viewModel.updateLastEntryY(dataValue.toFloat(), yes)
+                                        "numeric" -> viewModel.updateLastEntryY(dataValue.toFloat(), true)
                                         "timeBased" -> viewModel.timeBasedDataUpdater(days, hours, minutes, seconds)
                                         "binary" -> viewModel.binaryDataUpdater(yes)
                                     }

--- a/app/src/main/java/com/example/habitflow/AddDataScreen.kt
+++ b/app/src/main/java/com/example/habitflow/AddDataScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import com.example.habitflow.model.Habit
 import com.example.habitflow.model.UserData
 import com.example.habitflow.viewmodel.AddDataViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 fun AddDataScreen(
@@ -29,6 +30,8 @@ fun AddDataScreen(
     var yes by remember { mutableStateOf(false) }
     var no by remember { mutableStateOf(false) }
     var showPrompt by remember { mutableStateOf(true) }
+
+    val coroutineScope = rememberCoroutineScope()
 
 
 
@@ -58,12 +61,15 @@ fun AddDataScreen(
                         onNoChecked = { no = true; yes = false },
                         buttonText = "Save Data",
                         onSubmitClick = {
-                            when (it.trackingMethod) {
-                                "numeric" -> viewModel.saveData(dataValue.toFloatOrNull())
-                                "timeBased" -> viewModel.timeBasedDataSaver(days, hours, minutes, seconds)
-                                "binary" -> viewModel.binaryDataSaver(yes)
+                            coroutineScope.launch {
+                                when (it.trackingMethod) {
+                                    // If they selected yes,
+                                    "numeric" -> viewModel.saveData(dataValue.toFloatOrNull(), yes)
+                                    "timeBased" -> viewModel.timeBasedDataSaver(days, hours, minutes, seconds)
+                                    "binary" -> viewModel.binaryDataSaver(yes)
+                                }
+                                navController.navigate("home/")
                             }
-                            navController.navigate("home/")
                         }
                     )
                 } else {
@@ -92,12 +98,14 @@ fun AddDataScreen(
                             onNoChecked = { no = true; yes = false },
                             buttonText = "Update Entry",
                             onSubmitClick = {
-                                when (it.trackingMethod) {
-                                    "numeric" -> viewModel.updateLastEntryY(dataValue.toFloat())
-                                    "timeBased" -> viewModel.timeBasedDataUpdater(days, hours, minutes, seconds)
-                                    "binary" -> viewModel.binaryDataUpdater(yes)
+                                coroutineScope.launch {
+                                    when (it.trackingMethod) {
+                                        "numeric" -> viewModel.updateLastEntryY(dataValue.toFloat(), yes)
+                                        "timeBased" -> viewModel.timeBasedDataUpdater(days, hours, minutes, seconds)
+                                        "binary" -> viewModel.binaryDataUpdater(yes)
+                                    }
+                                    navController.navigate("home/")
                                 }
-                                navController.navigate("home/")
                             }
                         )
                     }

--- a/app/src/main/java/com/example/habitflow/StatsPage.kt
+++ b/app/src/main/java/com/example/habitflow/StatsPage.kt
@@ -1,5 +1,6 @@
 package com.example.habitflow
 
+import android.util.Log
 import android.graphics.Color as AndroidColor
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -10,15 +11,34 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavController
 import com.github.mikephil.charting.charts.BarChart
 import com.github.mikephil.charting.charts.LineChart
 import com.github.mikephil.charting.components.Description
 import com.github.mikephil.charting.data.*
 
+import com.example.habitflow.viewmodel.StatsPageViewModel
+import com.example.habitflow.viewmodel.StatsPageViewModelFactory
+import com.github.mikephil.charting.components.XAxis
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StatsPage(navController: NavController) {
+    val viewModel: StatsPageViewModel = viewModel()
+    val totalHabits by viewModel.totalHabits.collectAsState()
+    val longestStreak by viewModel.longestStreak.collectAsState()
+    val completionsThisWeek by viewModel.completionsThisWeek.collectAsState()
+    val dailyCompletions by viewModel.dailyCompletions.collectAsState()
+    val averageStreaks by viewModel.averageStreaks.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadStats()
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
 
         // This is all the Top Bar
@@ -58,23 +78,88 @@ fun StatsPage(navController: NavController) {
         ) {
             Spacer(modifier = Modifier.height(20.dp))
 
-            Text("Total Habits: 7")
-            Text("Longest Streak: 12 days")
-            Text("Habits Completed This Week: 24")
+            Text("Total Habits: $totalHabits")
+            Text("Longest Streak: $longestStreak days")
+            Text("Habits Completed This Week: $completionsThisWeek")
 
             Spacer(modifier = Modifier.height(30.dp))
 
+            Log.d("StatsDebug", "Line chart data: $averageStreaks")
+            Log.d("StatsDebug", "Bar chart data: $dailyCompletions")
+
             Text("Weekly Streak Progress", style = MaterialTheme.typography.titleLarge)
-            LineChartView(data = listOf(1f, 3f, 5f, 4f, 6f, 7f, 8f))
+            LineChartView(data = averageStreaks)
 
             Spacer(modifier = Modifier.height(30.dp))
 
             Text("Habits Completed Per Day", style = MaterialTheme.typography.titleLarge)
-            BarChartView(data = listOf(2f, 3f, 5f, 4f, 6f, 4f, 7f))
+            BarChartView(data = dailyCompletions)
         }
     }
 }
 
+@Composable
+fun LineChartView(data: List<Float>) {
+    val entries = data.mapIndexed { index, value -> Entry(index.toFloat(), value) }
+    val lineData = LineData(LineDataSet(entries, "Streak").apply {
+        color = AndroidColor.BLUE
+        valueTextColor = AndroidColor.BLACK
+        circleRadius = 4f
+        setDrawValues(false)
+        setDrawCircles(true)
+    })
+
+    AndroidView(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp),
+        factory = { context ->
+            LineChart(context).apply {
+                this.description = Description().apply { text = "" }
+                this.axisLeft.axisMinimum = 0f
+                this.axisRight.isEnabled = false
+                this.xAxis.position = XAxis.XAxisPosition.BOTTOM
+                this.legend.isEnabled = false
+            }
+        },
+        update = { chart ->
+            chart.data = lineData
+            chart.invalidate()
+        }
+    )
+}
+
+
+@Composable
+fun BarChartView(data: List<Float>) {
+    val entries = data.mapIndexed { index, value -> BarEntry(index.toFloat(), value) }
+    val barData = BarData(BarDataSet(entries, "Completions").apply {
+        color = AndroidColor.MAGENTA
+        valueTextColor = AndroidColor.BLACK
+        setDrawValues(false)
+    })
+
+    AndroidView(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp),
+        factory = { context ->
+            BarChart(context).apply {
+                this.description = Description().apply { text = "" }
+                this.axisLeft.axisMinimum = 0f
+                this.axisRight.isEnabled = false
+                this.xAxis.position = XAxis.XAxisPosition.BOTTOM
+                this.legend.isEnabled = false
+            }
+        },
+        update = { chart ->
+            chart.data = barData
+            chart.invalidate()
+        }
+    )
+}
+
+/*
 @Composable
 fun LineChartView(data: List<Float>) {
     val entries = data.mapIndexed { index, value -> Entry(index.toFloat(), value) }
@@ -123,5 +208,4 @@ fun BarChartView(data: List<Float>) {
         }
     )
 }
-
-
+*/

--- a/app/src/main/java/com/example/habitflow/model/UserData.kt
+++ b/app/src/main/java/com/example/habitflow/model/UserData.kt
@@ -16,7 +16,7 @@ data class UserData (
     val type: String = "",
     var userData: List<Entry> = emptyList(),
     var lastUpdated: Timestamp = Timestamp.now(),
-    val streak: Int = calculateStreak(userData),
+    val streak: Int,
     val createDate: Timestamp,
     val deadline: String? = null,
     val deadlineAsTimestamp: Timestamp? = parseDeadlineToTimestamp(deadline),

--- a/app/src/main/java/com/example/habitflow/repository/DataRepository.kt
+++ b/app/src/main/java/com/example/habitflow/repository/DataRepository.kt
@@ -151,7 +151,7 @@ class DataRepository {
 
                 // If both timestamp and value are present, create an Entry
                 if (timestamp != null && value != null) {
-                    Entry(timestamp.seconds.toFloat(), value)
+                    Entry(timestamp.toDate().time.toFloat(), value)
                 } else {
                     null
                 }
@@ -160,7 +160,7 @@ class DataRepository {
 
         return UserData(
             userDataId = userDataId,
-            userData = calculateTimeDifferences(rawEntries),
+            userData = rawEntries, //calculateTimeDifferences(rawEntries),
             lastUpdated = data?.get("lastUpdated") as? Timestamp ?: Timestamp.now(),
             createDate = data?.get("createDate") as? Timestamp ?: Timestamp.now(),
             deadline = data?.get("deadline") as? String ?: "",

--- a/app/src/main/java/com/example/habitflow/repository/DataRepository.kt
+++ b/app/src/main/java/com/example/habitflow/repository/DataRepository.kt
@@ -6,6 +6,7 @@ import com.github.mikephil.charting.data.Entry
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue
+import kotlinx.coroutines.tasks.await
 
 class DataRepository {
 
@@ -39,21 +40,48 @@ class DataRepository {
             }
     }
 
-    fun updateUserData(userDataId: String, newData: Map<String, Any>, currentTimestamp: Timestamp) {
+    suspend fun updateUserData(userDataId: String, newEntry: Map<String, Any>, didCompleteHabit: Boolean) {
         val db = getDatabase()
-        db.collection("userData")
-            .document(userDataId)
-            .update(
-                "data", FieldValue.arrayUnion(newData),
-                "lastUpdated", currentTimestamp
-            )
-            .addOnSuccessListener {
-                Log.d("DataRepository", "Data successfully updated")
-            }
-            .addOnFailureListener { exception ->
-                Log.e("DataRepository", "Error updating data: ${exception.message}")
-            }
+        val userDataRef = db.collection("userData").document(userDataId)
+
+        val snapshot = userDataRef.get().await()
+        val data = (snapshot.get("data") as? List<Map<String, Any>>)?.toMutableList() ?: mutableListOf()
+
+        // Get previous streak, default to 0 if absent
+        val lastStreak = data.lastOrNull()?.get("streak") as? Long ?: 0L
+        val newStreak = if (didCompleteHabit) lastStreak + 1 else 0
+        val enrichedEntry = newEntry.toMutableMap()
+        enrichedEntry["streak"] = newStreak
+
+        // Append the new entry (instead of using arrayUnion)
+        data.add(enrichedEntry)
+
+        // Write back the full array
+        userDataRef.update(
+            "data", data,
+            "lastUpdated", Timestamp.now()
+        ).addOnSuccessListener {
+            Log.d("DataRepository", "Full entry with streak added successfully.")
+        }.addOnFailureListener { exception ->
+            Log.e("DataRepository", "Error writing entry with streak: ${exception.message}")
+        }
     }
+
+//    fun updateUserData(userDataId: String, newData: Map<String, Any>, currentTimestamp: Timestamp) {
+//        val db = getDatabase()
+//        db.collection("userData")
+//            .document(userDataId)
+//            .update(
+//                "data", FieldValue.arrayUnion(newData),
+//                "lastUpdated", currentTimestamp
+//            )
+//            .addOnSuccessListener {
+//                Log.d("DataRepository", "Data successfully updated")
+//            }
+//            .addOnFailureListener { exception ->
+//                Log.e("DataRepository", "Error updating data: ${exception.message}")
+//            }
+//    }
 
     fun loadUserDataFromFirestore(
         userDataId: String,
@@ -158,9 +186,14 @@ class DataRepository {
             }
         } ?: emptyList()
 
+        val streakFromEntry = (data?.get("data") as? List<Map<String, Any>>)
+            ?.lastOrNull()
+            ?.get("streak") as? Number ?: 1
+
         return UserData(
             userDataId = userDataId,
             userData = rawEntries, //calculateTimeDifferences(rawEntries),
+            streak = streakFromEntry.toInt(),
             lastUpdated = data?.get("lastUpdated") as? Timestamp ?: Timestamp.now(),
             createDate = data?.get("createDate") as? Timestamp ?: Timestamp.now(),
             deadline = data?.get("deadline") as? String ?: "",

--- a/app/src/main/java/com/example/habitflow/viewmodel/AddDataViewModel.kt
+++ b/app/src/main/java/com/example/habitflow/viewmodel/AddDataViewModel.kt
@@ -7,6 +7,8 @@ import com.example.habitflow.model.UserData
 import com.example.habitflow.repository.DataRepository
 import com.github.mikephil.charting.data.Entry
 import com.google.firebase.Timestamp
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
 
 class AddDataViewModel(
     private val dataRepository: DataRepository = DataRepository()
@@ -24,27 +26,40 @@ class AddDataViewModel(
         this.userDataId = userData.userDataId
     }
 
-    fun saveData(value: Float?) {
+    suspend fun saveData(value: Float?, didCompleteHabit: Boolean) {
         if (value == null) return
         val userDataId = this.userDataId
+        val timestamp = Timestamp.now()
+        val entry = mapOf(
+            "value" to value,
+            "timestamp" to timestamp
+        )
         userDataId?.let {
-            val currentTimestamp = Timestamp.now()
-            val newData = mapOf(
-                "value" to value,
-                "timestamp" to currentTimestamp
-            )
-            dataRepository.updateUserData(userDataId, newData, currentTimestamp)
+            dataRepository.updateUserData(it, entry, didCompleteHabit)
         }
     }
 
-    fun timeBasedDataSaver(days: Int, hours: Int, minutes: Int, seconds: Int) {
+//    fun saveData(value: Float?) {
+//        if (value == null) return
+//        val userDataId = this.userDataId
+//        userDataId?.let {
+//            val currentTimestamp = Timestamp.now()
+//            val newData = mapOf(
+//                "value" to value,
+//                "timestamp" to currentTimestamp
+//            )
+//            dataRepository.updateUserData(userDataId, newData, currentTimestamp)
+//        }
+//    }
+
+    suspend fun timeBasedDataSaver(days: Int, hours: Int, minutes: Int, seconds: Int) {
         val value =  calculateTimeBasedValue(days, hours, minutes, seconds)
-        saveData(value)
+        saveData(value, didCompleteHabit = true) // Always assume
     }
 
-    fun timeBasedDataUpdater(days: Int, hours: Int, minutes: Int, seconds: Int) {
+    suspend fun timeBasedDataUpdater(days: Int, hours: Int, minutes: Int, seconds: Int) {
         val value = calculateTimeBasedValue(days, hours, minutes, seconds)
-        updateLastEntryY(value)
+        updateLastEntryY(value, didCompleteHabit = true)
     }
 
     // Helper function for time based data for saveData() and updateLastEntryY()
@@ -53,49 +68,98 @@ class AddDataViewModel(
         return totalSeconds.toFloat()
     }
 
-    fun binaryDataSaver(completed: Boolean) {
-        val value = calculateBinaryValue(completed)
-        saveData(value)
+    suspend fun binaryDataSaver(completed: Boolean) {
+        val value = if (completed) 1f else 0f
+        saveData(value, didCompleteHabit = completed)
     }
 
-    fun binaryDataUpdater(completed: Boolean) {
-        val value = calculateBinaryValue(completed)
-        updateLastEntryY(value)
+    suspend fun binaryDataUpdater(completed: Boolean) {
+        val value = if (completed) 1f else 0f
+        updateLastEntryY(value, completed)
     }
 
-    // Helper function for binary based data for saveData() and updateLastEntryY()
-    private fun calculateBinaryValue(completed: Boolean): Float {
-        val valueToAdd = if (completed) 1f else -1f
-        val lastY = userData?.userData?.lastOrNull()?.y ?: 0f
+//    suspend fun binaryDataSaver(completed: Boolean) {
+//        val value = calculateBinaryValue(completed)
+//        saveData(value)
+//    }
+//
+//    fun binaryDataUpdater(completed: Boolean) {
+//        val value = calculateBinaryValue(completed)
+//        updateLastEntryY(value)
+//    }
 
-        val updatedY = (lastY + valueToAdd).coerceAtLeast(0f)
-        return updatedY
-    }
+//    // Helper function for binary based data for saveData() and updateLastEntryY()
+//    private fun calculateBinaryValue(completed: Boolean): Float {
+//        val valueToAdd = if (completed) 1f else -1f
+//        val lastY = userData?.userData?.lastOrNull()?.y ?: 0f
+//
+//        val updatedY = (lastY + valueToAdd).coerceAtLeast(0f)
+//        return updatedY
+//    }
 
     fun getLastEntryY(): Float? {
         return userData?.userData?.lastOrNull()?.y
     }
 
-    fun updateLastEntryY(newY: Float) {
+    suspend fun updateLastEntryY(newY: Float, didCompleteHabit: Boolean) {
         val userDataId = this.userDataId
         val userData = this.userData
 
         if (userDataId != null && userData != null && userData.userData.isNotEmpty()) {
-            val lastIndex = userData.userData.lastIndex
-            val lastEntry = userData.userData[lastIndex]
-            val updatedEntry = Entry(lastEntry.x, newY)
+            val currentTimestamp = Timestamp.now()
 
-            val updatedList = userData.userData.toMutableList().apply {
-                this[lastIndex] = updatedEntry
+            val snapshot = FirebaseFirestore.getInstance()
+                .collection("userData").document(userDataId).get().await()
+
+            val data = (snapshot.get("data") as? List<Map<String, Any>>)?.toMutableList() ?: return
+
+            val lastStreak = data.lastOrNull()?.get("streak") as? Long ?: 0L
+            val newStreak = if (didCompleteHabit) lastStreak + 1 else 0
+
+
+            val updatedEntry = mapOf(
+                "value" to newY,
+                "timestamp" to currentTimestamp,
+                "streak" to newStreak
+            )
+
+            // Replace last entry
+            data[data.lastIndex] = updatedEntry
+
+            snapshot.reference.update(
+                "data", data,
+                "lastUpdated", currentTimestamp
+            ).addOnSuccessListener {
+                Log.d("EntryDebug", "Updated last entry with streak: $updatedEntry")
+            }.addOnFailureListener { e: Exception ->
+                Log.e("EntryDebug", "Failed to update last entry: ${e.message}")
             }
-
-            userData.userData = updatedList
-
-            dataRepository.updateLastEntryInFirestore(userDataId, updatedEntry)
         } else {
-            Log.e("UpdateEntry", "Could not update last entry. Missing userData or userDataId or entries empty.")
+            Log.e("UpdateEntry", "Missing userData or userDataId or empty list")
         }
     }
+
+
+//    fun updateLastEntryY(newY: Float) {
+//        val userDataId = this.userDataId
+//        val userData = this.userData
+//
+//        if (userDataId != null && userData != null && userData.userData.isNotEmpty()) {
+//            val lastIndex = userData.userData.lastIndex
+//            val lastEntry = userData.userData[lastIndex]
+//            val updatedEntry = Entry(lastEntry.x, newY)
+//
+//            val updatedList = userData.userData.toMutableList().apply {
+//                this[lastIndex] = updatedEntry
+//            }
+//
+//            userData.userData = updatedList
+//
+//            dataRepository.updateLastEntryInFirestore(userDataId, updatedEntry)
+//        } else {
+//            Log.e("UpdateEntry", "Could not update last entry. Missing userData or userDataId or entries empty.")
+//        }
+//    }
 
     fun retrieveHabit(): Habit? {
         return habit

--- a/app/src/main/java/com/example/habitflow/viewmodel/StatsPageViewModel.kt
+++ b/app/src/main/java/com/example/habitflow/viewmodel/StatsPageViewModel.kt
@@ -1,0 +1,117 @@
+/*
+This ViewModel was developed using assistance from ChatGPT (April 2025),
+    which provided implementation support based on a my (Drew) self-defined specification.
+*/
+
+package com.example.habitflow.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.habitflow.model.UserData
+import com.example.habitflow.repository.DataRepository
+import com.example.habitflow.repository.HabitRepository
+import com.github.mikephil.charting.data.Entry
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.Calendar
+import java.util.Date
+
+class StatsPageViewModel(
+    private val dataRepository: DataRepository = DataRepository(),
+    private val habitRepository: HabitRepository = HabitRepository,
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+) : ViewModel() {
+
+    private val _totalHabits = MutableStateFlow(0)
+    val totalHabits: StateFlow<Int> = _totalHabits.asStateFlow()
+
+    private val _longestStreak = MutableStateFlow(0)
+    val longestStreak: StateFlow<Int> = _longestStreak.asStateFlow()
+
+    private val _completionsThisWeek = MutableStateFlow(0)
+    val completionsThisWeek: StateFlow<Int> = _completionsThisWeek.asStateFlow()
+
+    private val _dailyCompletions = MutableStateFlow<List<Float>>(emptyList())
+    val dailyCompletions: StateFlow<List<Float>> = _dailyCompletions.asStateFlow()
+
+    private val _averageStreaks = MutableStateFlow<List<Float>>(emptyList())
+    val averageStreaks: StateFlow<List<Float>> = _averageStreaks.asStateFlow()
+
+    fun loadStats() {
+        val user = auth.currentUser ?: return
+        viewModelScope.launch {
+            habitRepository.loadHabitsFromFirestore(
+                user,
+                onSuccess = { habitIds ->
+                    if (habitIds.isEmpty()) return@loadHabitsFromFirestore
+
+                    _totalHabits.value = habitIds.size
+
+                    val allUserData = mutableListOf<UserData>()
+                    var loaded = 0
+
+                    for (id in habitIds) {
+                        habitRepository.getHabitFromFirestore(id) { habit ->
+                            val userDataId = habit?.userDataId ?: return@getHabitFromFirestore
+                            dataRepository.loadUserDataFromFirestore(userDataId) { result ->
+                                result.onSuccess { userData ->
+                                    allUserData.add(userData)
+                                }
+                                loaded++
+                                if (loaded == habitIds.size) {
+                                    computeStats(allUserData)
+                                }
+                            }
+                        }
+                    }
+                },
+                onFailure = {}
+            )
+        }
+    }
+
+    private fun computeStats(userDataList: List<UserData>) {
+        if (userDataList.isEmpty()) return
+
+        _longestStreak.value = userDataList.maxOfOrNull { it.streak } ?: 0
+
+        val calendar = Calendar.getInstance()
+        calendar.time = Date()
+        calendar.add(Calendar.DAY_OF_YEAR, -6) // 7-day window
+        val sevenDaysAgo = calendar.time
+
+        val completionsPerDay = IntArray(7) { 0 }
+        val streaksPerDay = Array(7) { mutableListOf<Int>() }
+
+        for (userData in userDataList) {
+            for (entry in userData.userData) {
+                val entryDate = Date(entry.x.toLong())
+                if (entryDate.after(sevenDaysAgo)) {
+                    val dayIndex = getDayIndex(entryDate)
+                    completionsPerDay[dayIndex]++
+                    streaksPerDay[dayIndex].add(userData.streak)
+                }
+            }
+        }
+
+        _completionsThisWeek.value = completionsPerDay.sum()
+        _dailyCompletions.value = completionsPerDay.map { it.toFloat() }
+        _averageStreaks.value = streaksPerDay.map { dayStreaks ->
+            if (dayStreaks.isNotEmpty()) dayStreaks.average().toFloat() else 0f
+        }
+    }
+
+    private fun getDayIndex(date: Date): Int {
+        val today = Calendar.getInstance()
+        today.time = Date()
+
+        val target = Calendar.getInstance()
+        target.time = date
+
+        val diff = ((today.time.time - target.time.time) / (1000 * 60 * 60 * 24)).toInt()
+        return 6 - diff.coerceIn(0, 6)
+    }
+}

--- a/app/src/main/java/com/example/habitflow/viewmodel/StatsPageViewModelFactory.kt
+++ b/app/src/main/java/com/example/habitflow/viewmodel/StatsPageViewModelFactory.kt
@@ -1,0 +1,21 @@
+package com.example.habitflow.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.habitflow.repository.DataRepository
+import com.example.habitflow.repository.HabitRepository
+import com.google.firebase.auth.FirebaseAuth
+
+class StatsPageViewModelFactory(
+    private val dataRepository: DataRepository,
+    private val habitRepository: HabitRepository,
+    private val auth: FirebaseAuth
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(StatsPageViewModel::class.java)) {
+            return StatsPageViewModel(dataRepository, habitRepository, auth) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
Extends stats page to use real data instead of hard-codeded values, adjusts streak tracking to reset when more than 24 hours have passed between two entries of numeric data, or when you mark a habit not-completed for binary data. Does not currently handle resetting streaks on time data.